### PR TITLE
Update github output syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ runs:
     - id: context
       shell: bash
       run: |
-          echo "::set-output name=action-result::${{ inputs.param1 }}"
+          echo "action-result=${{ inputs.param1 }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/